### PR TITLE
Styling for splitting screen and add selection amounts for items.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "bootstrap": "4.3.1",
+    "classnames": "^2.2.6",
     "jquery": "3.3.1",
     "react": "^16.8.4",
     "react-bootstrap": "1.0.0-beta.5",

--- a/src/components/divvyItem.js
+++ b/src/components/divvyItem.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import {Card} from 'react-bootstrap';
+
+export default props => {
+  const {
+    onItemClick,
+    item,
+  } = props;
+  const splitForItem = item.splits.length === 0 ?
+    <div style={{
+        flex: 1,
+        height: '2rem',
+      }}>
+    </div>
+    :
+    item.splits.map(function(portion) {
+      return(
+        <div style={{
+          backgroundColor: portion.color,
+          flex: portion.size,
+          height: '2rem',
+        }}>
+        </div>
+      )
+  });
+  return (
+    <Card className=" divvy-item" border='dark' onClick={onItemClick}>
+      <Card.Img variant="top" src={item.image} />
+      <div className='flex-row d-flex'> {splitForItem} </div>
+    </Card>
+  );
+}

--- a/src/components/itemModal.js
+++ b/src/components/itemModal.js
@@ -15,7 +15,7 @@ class ItemModal extends React.Component {
     this.toggleButton = this.toggleButton.bind(this);
   }
   componentWillReceiveProps(nextProps, nextContext) {
-    if(nextProps.cost !== this.state.props || nextProps.amount !== this.state.props) {
+    if(nextProps.cost !== this.state.cost || nextProps.amount !== this.state.amount) {
       this.setState({
         cost: nextProps.cost,
         amount: nextProps.amount

--- a/src/components/itemModal.js
+++ b/src/components/itemModal.js
@@ -1,10 +1,51 @@
-import React, { Component } from 'react';
-import { Modal, ButtonGroup, ButtonToolbar, ToggleButtonGroup, ToggleButton } from 'react-bootstrap';
+import React from 'react';
+import classNames from 'classnames';
+import { Modal, ButtonToolbar, ToggleButtonGroup, ToggleButton } from 'react-bootstrap';
 import Button from 'react-bootstrap/Button';
 import { Container, Row, Col, Form } from 'react-bootstrap';
 
 class ItemModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      cost: props.cost,
+      amount: props.amount,
+    };
+    this.onAmountPressed = this.onAmountPressed.bind(this);
+    this.toggleButton = this.toggleButton.bind(this);
+  }
+  componentWillReceiveProps(nextProps, nextContext) {
+    if(nextProps.cost !== this.state.props || nextProps.amount !== this.state.props) {
+      this.setState({
+        cost: nextProps.cost,
+        amount: nextProps.amount
+      })
+    }
+  }
+
+  onAmountPressed(e) {
+    this.setState({amount: e.target.value})
+  }
+  toggleButton(type, value, text) {
+
+    const classes = classNames('ItemModalButton', {
+      'mb-4': value === -1,
+      'active': this.state.amount === value
+    });
+    return <ToggleButton
+      className={classes}
+      variant={type}
+      value={value}
+      onChange={this.onAmountPressed}>{text}</ToggleButton>
+  }
   render() {
+    const buttons = [{type: 'info', value: -1, text: "All"},
+      {type: 'danger', value: 1, text: "Much Less"},
+      {type: 'warning', value: 2, text: "Less"},
+      {type: 'success', value: 3, text: "Average"},
+      {type: 'warning', value: 4, text: "More"},
+      {type: 'danger', value: 5, text: "Much More"}
+    ].map(val =>  this.toggleButton(val.type,val.value,val.text));
     return <div> 
       <Modal show={this.props.showModal} onHide={this.props.onHide} >
         <Modal.Header closeButton>
@@ -15,7 +56,7 @@ class ItemModal extends React.Component {
           <Container>
             <Form>
               <Form.Group as={Row}>
-                <div><img src={this.props.receiptImage}/></div>
+                <div><img alt='receipt item image' src={this.props.receiptImage}/></div>
                 <Form.Label column xs="6">This item costs:</Form.Label>
                 <Col xs="6">
                   <Form.Control type="number"
@@ -23,11 +64,13 @@ class ItemModal extends React.Component {
                     step="0.01"
                     data-number-to-fixed="2"
                     data-number-stepfactor="100"
-                    placeholder="$"></Form.Control>
+                    placeholder="$"
+                    value={this.state.cost}
+                    onChange={(e) => this.setState({cost: e.target.value})}/>
                 </Col>
               </Form.Group>
             </Form>
-            <hr></hr>
+            <hr/>
             <Row className="pb-2">
               <Col>Compared to others, you had:</Col>
             </Row>
@@ -35,12 +78,7 @@ class ItemModal extends React.Component {
               <Col >
                 <ButtonToolbar className="justify-content-center">
                   <ToggleButtonGroup vertical className="btn-block" type="radio" name="ratio" size="lg">
-                    <ToggleButton className="ItemModalButton mb-4" variant="info" value={-1} >All</ToggleButton>
-                    <ToggleButton className="ItemModalButton" variant="danger" value={1} >Much Less</ToggleButton>
-                    <ToggleButton className="ItemModalButton" variant="warning" value={2} >Less</ToggleButton>
-                    <ToggleButton className="ItemModalButton" variant="success" value={3} >Average</ToggleButton>
-                    <ToggleButton className="ItemModalButton" variant="warning" value={4} >More</ToggleButton>
-                    <ToggleButton className="ItemModalButton" variant="danger" value={5} >Much More</ToggleButton>
+                    {buttons}
                   </ToggleButtonGroup>
                 </ButtonToolbar>
               </Col>
@@ -49,7 +87,7 @@ class ItemModal extends React.Component {
         </Modal.Body>
 
         <Modal.Footer>
-          <Button variant="primary" onClick={this.props.onButtonClick}>Save changes</Button>
+          <Button variant="primary" onClick={() => this.props.onButtonClick(this.state.cost, this.state.amount)}>Save changes</Button>
         </Modal.Footer>
     </Modal></div>;
   }

--- a/src/screens/splitting.js
+++ b/src/screens/splitting.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 import ItemModal from '../components/itemModal';
+import DivvyItem from '../components/divvyItem';
 import { Link } from 'react-router-dom';
 import image1 from '../mightySquirell.png';
 import image2 from '../taterTots.png';
@@ -11,54 +12,96 @@ import image5 from '../cheeseCake.png';
 class Splitting extends React.Component {
   constructor(props) {
     super(props);
-    var imgs = [];
-    imgs.push(image1);
-    imgs.push(image2);
-    imgs.push(image3);
-    imgs.push(image4);
-    imgs.push(image5);
-    this.state = { 
-        activeModal: -1,
-        images: imgs,
-        showModal: false
+    const items = []; //TODO add backend support
+    items.push({image: image1,
+                cost: 12.00,
+                splits: [
+                  {color:'blue', size:1},
+                  {color:'green', size:2},
+                ]});
+    items.push({image: image2, cost: 0, splits:[]});
+    items.push({image: image3, cost: 0, splits:[]});
+    items.push({image: image4, cost: 0, splits:[]});
+    items.push({image: image5, cost: 0, splits:[]});
+    this.state = {
+      activeModal: -1,
+      items: items,
+      showModal: false,
+      selectedCost: null,
+      selectedAmount: null,
     };
     this.getSetModal = this.getSetModal.bind(this);
+    this.onModalButton = this.onModalButton.bind(this);
+    this.hideModal = this.hideModal.bind(this);
   }
 
   hideModal() {
-    console.log("oh");
-     this.setState({showModal: false});
+    this.setState({
+      showModal: false
+    });
+  }
+  onModalButton(cost, amount) {
+    // 1. Make a shallow copy of the items
+    let items = [...this.state.items];
+    // 2. Make a shallow copy of the item you want to mutate
+    let item = {...items[this.state.activeModal]};
+    // 3. Replace the property you're interested in
+    let splits = item.splits;
+    splits.push({color:'red', size:amount});
+    item.splits = splits;
+    item.cost = cost;
+    // 4. Put it back into our array. N.B. we *are* mutating the array here, but that's why we made a copy first
+    items[this.state.activeModal] = item;
+    // 5. Set the state to our new copy
+    this.setState({
+      items: items,
+      showModal: false,
+    });
   }
 
-  getSetModal(image, index) {
-      return function () {
-        this.setState({
-            activeModal: index,
-            showModal: true,
-            modalImage: image,
-          })
-      }.bind(this)
+  getSetModal(item, index) {
+    return function () {
+      this.setState({
+        activeModal: index,
+        showModal: true,
+        modalImage: item.image,
+        selectedAmount: null, //TODO figure out how to get amount,
+        selectedCost: item.cost
+      })
+    }.bind(this)
   }
 
-    render() {
-      console.log("render");
-        return (
-            <div>
-              <h1>Divvy Items</h1>
-              <div className="row">
-                <div className="container">
-                    {this.state.images.map(function(image, i) {
-                        return (
-                            <div className="row divvy-item" onClick={this.getSetModal(image, i)}>
-                                <div><img src={image}/></div>
-                                {/*(this.state.activeModal == i ? <div><ItemModal showModal={() => {this.state.showModal}} onHide={this.hideModal.bind(this)} onButtonClick={this.hideModal.bind(this)} /></div> : null)*/}
-                            </div>);
-                        }, this)}
-                </div>
-                <ItemModal receiptImage={this.state.modalImage} showModal={this.state.showModal} onHide={this.hideModal.bind(this)} onButtonClick={this.hideModal.bind(this)} />
-                </div>
-              <Link to='/waiting'><Button variant="success">Finish</Button></Link>
-            </div>);
-    }
+  render() {
+    return (
+      <div>
+        <h1>Divvy Items</h1>
+        <div className="row">
+          <div className="container">
+            {this.state.items.map(function(item, i) {
+              return (
+                <DivvyItem item={item}
+                           onItemClick={() => this.setState({
+                             activeModal: i,
+                             showModal: true,
+                             modalImage: item.image,
+                             selectedItemIndex: i,
+                             selectedAmount: null, //TODO figure out how to get amount from splits
+                             selectedCost: item.cost
+                           })}
+                />);
+            }, this)}
+          </div>
+          <ItemModal receiptImage={this.state.modalImage}
+                     showModal={this.state.showModal}
+                     amount={this.state.selectedAmount}
+                     cost={this.state.selectedCost}
+                     onHide={this.hideModal}
+                     onButtonClick={this.onModalButton} />
+        </div>
+        <div className="row my-2 mx-0">
+          <Link to='/waiting'><Button variant="success">Finish</Button></Link>
+        </div>
+      </div>);
+  }
 }
 export default Splitting;

--- a/src/screens/splitting.js
+++ b/src/screens/splitting.js
@@ -30,7 +30,6 @@ class Splitting extends React.Component {
       selectedCost: null,
       selectedAmount: null,
     };
-    this.getSetModal = this.getSetModal.bind(this);
     this.onModalButton = this.onModalButton.bind(this);
     this.hideModal = this.hideModal.bind(this);
   }
@@ -57,18 +56,6 @@ class Splitting extends React.Component {
       items: items,
       showModal: false,
     });
-  }
-
-  getSetModal(item, index) {
-    return function () {
-      this.setState({
-        activeModal: index,
-        showModal: true,
-        modalImage: item.image,
-        selectedAmount: null, //TODO figure out how to get amount,
-        selectedCost: item.cost
-      })
-    }.bind(this)
   }
 
   render() {


### PR DESCRIPTION
I added more style to the item splitting screen and made it hopefully clearer that items are selectable and some items are selected and how much of them are selected. (this logic isn't 100 there, but is at least partially working). Also now item cost is shown in the modal and is redisplayed when you reopen the modal. 
![Screenshot from 2019-03-25 19-53-38](https://user-images.githubusercontent.com/9651994/54962140-280aba80-4f3a-11e9-8afd-0f153d50fc2b.png)
