### PR TITLE
Fix perspective crop so there isn't weird space around things.

### DIFF
--- a/src/components/Crop.js
+++ b/src/components/Crop.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+
+class Crop extends Component {
+
+  componentDidMount() {
+    const canvas = this.refs.canvas;
+    const ctx = canvas.getContext("2d");
+    canvas.width=this.props.width;
+    canvas.height=this.props.height;
+    ctx.drawImage(
+      this.props.canvas,
+      this.props.x,
+      this.props.y,
+      this.props.cropWidth,
+      this.props.cropHeight,
+      0,
+      0,
+      this.props.width,
+      this.props.height
+    );
+    canvas.toBlob((blob) => {
+      console.log(blob);
+      this.props.imageCallback(blob);
+    });
+  }
+
+  render() {
+    return(
+      <div className={this.props.displayNone ? 'd-none' : ''}>
+        <canvas ref="canvas"
+                width={this.props.width}
+                height={this.props.height}
+                onClick={this.props.handleClick}/>
+      </div>
+    )
+  }
+}
+export default Crop;

--- a/src/components/perspectiveCrop.js
+++ b/src/components/perspectiveCrop.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-
+import Crop from './Crop';
 //NOTE: Do not give a image to this component that needs to be scaled.
 //Instead scale it convert it to a blob and then use that blob here. 
 //Things break and im too lazy to fix them with scaling.
@@ -7,15 +7,14 @@ class PerspectiveCrop extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      img: new Image()
+      img: new Image(),
+      canvas: null
     };
 
   }
   
   componentDidMount() {
     const canvas = this.refs.canvas;
-    const hiddenCanvas = this.refs.hiddenCanvas;
-    const hiddenCtx = hiddenCanvas.getContext('2d');
     const ctx = canvas.getContext("2d");
     // eslint-disable-next-line
     this.state.img.onload = () => {
@@ -28,22 +27,8 @@ class PerspectiveCrop extends Component {
       // unwarp the source rectangle and draw it to the destination canvas
       this.unwarp(this.props.anchors,this.props.unwarped,ctx);
       //In order to make it so that we get back a image that doesn't have any transparancy around it
-      //we need to crop it with this hidden canvas.
-      hiddenCtx.drawImage(
-        canvas,
-        0,
-        1,
-        this.props.width -1,
-        this.props.height -1,
-        0,
-        0,
-        this.props.width,
-        this.props.height
-      );
-      hiddenCanvas.toBlob((blob) => {
-
-        this.props.imageCallback(blob);
-      });
+      //we need to crop it. To signal this we set the canvas state
+      this.setState({canvas: canvas});
 
 
     };
@@ -55,14 +40,21 @@ class PerspectiveCrop extends Component {
     return(
       <div>
         <canvas ref="canvas"
-      width={this.props.width}
-      height={this.props.height}
-      onClick={this.props.handleClick}/>
-        <canvas ref='hiddenCanvas'
-                className='d-none'
+          width={this.props.width}
+          height={this.props.height}
+          onClick={this.props.handleClick}/>
+
+        {this.state.canvas !== null ?
+          <Crop displayNone={true}
+                canvas={this.state.canvas}
                 width={this.props.width}
                 height={this.props.height}
-        />
+                cropWidth={this.props.width - 1}
+                cropHeight={this.props.height - 1}
+                x={0}
+                y={1}
+                imageCallback={this.props.imageCallback}
+          /> :<> </>}
       </div>
     )
   }

--- a/src/components/perspectiveCrop.js
+++ b/src/components/perspectiveCrop.js
@@ -13,9 +13,11 @@ class PerspectiveCrop extends Component {
   }
   
   componentDidMount() {
-    const canvas = this.refs.canvas
-    const ctx = canvas.getContext("2d")
-    // eslint-disable-next-line 
+    const canvas = this.refs.canvas;
+    const hiddenCanvas = this.refs.hiddenCanvas;
+    const hiddenCtx = hiddenCanvas.getContext('2d');
+    const ctx = canvas.getContext("2d");
+    // eslint-disable-next-line
     this.state.img.onload = () => {
       
       canvas.width=this.props.width;
@@ -25,10 +27,26 @@ class PerspectiveCrop extends Component {
 
       // unwarp the source rectangle and draw it to the destination canvas
       this.unwarp(this.props.anchors,this.props.unwarped,ctx);
-      canvas.toBlob((blob) => {
+      //In order to make it so that we get back a image that doesn't have any transparancy around it
+      //we need to crop it with this hidden canvas.
+      hiddenCtx.drawImage(
+        canvas,
+        0,
+        1,
+        this.props.width -1,
+        this.props.height -1,
+        0,
+        0,
+        this.props.width,
+        this.props.height
+      );
+      hiddenCanvas.toBlob((blob) => {
+
         this.props.imageCallback(blob);
-      })
-    }
+      });
+
+
+    };
     // eslint-disable-next-line
     this.state.img.src = this.props.image;
   }
@@ -36,10 +54,15 @@ class PerspectiveCrop extends Component {
   render() {
     return(
       <div>
-        <canvas ref="canvas" 
-      width={this.props.width} 
-      height={this.props.height} 
+        <canvas ref="canvas"
+      width={this.props.width}
+      height={this.props.height}
       onClick={this.props.handleClick}/>
+        <canvas ref='hiddenCanvas'
+                className='d-none'
+                width={this.props.width}
+                height={this.props.height}
+        />
       </div>
     )
   }
@@ -57,6 +80,8 @@ class PerspectiveCrop extends Component {
                );
 
     // eliminate slight space between triangles
+    // NOTE: this adds a small space on the top/right of the image.
+    // we will move the image back and crop it later.
     context.translate(-1,1);
 
     // unwarp the top-right triangle of the warped polygon
@@ -64,7 +89,8 @@ class PerspectiveCrop extends Component {
                 anchors.TL,  anchors.TR,  anchors.BR,
                 unwarped.TL, unwarped.TR, unwarped.BR
                );
-
+    // Move the image back so that it is in the correct place and there is no transparency around it.
+    context.translate(1,-1);
   }
 
 


### PR DESCRIPTION
The way perspective crop works is that it does some matrix manipulation with images (as far as i can tell. It was from stack overflow). However it isnt perfect and when it transforms one half of the image it moves it so there will be no gap in the middle. But it doesn't move back and it also reduces the image size by one pixel in each direction. This causes there to be a transparent padding on two sides of the cropped image on the canvas, so when the canvas is saved to an image the transparency is noticeable (also it grows by one for every new item cropped). To fix this we just crop the cropped image with a hidden canvas and returned the properly cropped image instead. 

On the top is the before and the bottom is the after. (different items but they are both from the item cropper part)
![Screenshot from 2019-04-08 16-41-15](https://user-images.githubusercontent.com/9651994/55755499-269ebf00-5a1d-11e9-9e3e-0de4b0e96e89.png)
